### PR TITLE
#54 배치 정책 적용 및 코드 정리

### DIFF
--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/AnimalServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/AnimalServiceImpl.java
@@ -6,12 +6,14 @@ import com.papaolabs.api.infrastructure.persistence.restapi.feign.AnimalApiClien
 import com.papaolabs.api.interfaces.v1.dto.KindDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class AnimalServiceImpl implements AnimalService {
     @Value("${seoul.api.animal.appKey}")
     private String appKey;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/CommentServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/CommentServiceImpl.java
@@ -6,6 +6,7 @@ import com.papaolabs.api.infrastructure.persistence.jpa.repository.CommentReposi
 import com.papaolabs.api.infrastructure.persistence.jpa.repository.KindRepository;
 import com.papaolabs.api.interfaces.v1.dto.CommentDTO;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.constraints.NotNull;
 import java.text.ParseException;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 import static java.lang.Boolean.FALSE;
 
 @Service
+@Transactional
 public class CommentServiceImpl implements CommentService {
     private static final String DATE_FORMAT = "yyyyMMdd";
     @NotNull

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/PostServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/PostServiceImpl.java
@@ -10,6 +10,7 @@ import com.papaolabs.api.interfaces.v1.dto.type.StateType;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.constraints.NotNull;
 import java.text.ParseException;
@@ -28,6 +29,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Slf4j
 @Service
+@Transactional
 public class PostServiceImpl implements PostService {
     private static final String UNKNOWN = "UNKNOWN";
     private static final String DATE_FORMAT = "yyyyMMdd";

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/ShelterServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/ShelterServiceImpl.java
@@ -8,12 +8,14 @@ import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.ShelterApi
 import com.papaolabs.api.interfaces.v1.dto.ShelterDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class ShelterServiceImpl implements ShelterService {
     @Value("${seoul.api.animal.appKey}")
     private String appKey;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/StatsServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/StatsServiceImpl.java
@@ -5,6 +5,7 @@ import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.AnimalApiR
 import com.papaolabs.api.interfaces.v1.dto.StatsDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.util.List;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Service
+@Transactional
 public class StatsServiceImpl implements StatsService {
     @Value("${seoul.api.animal.appKey}")
     private String appKey;

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/JpaConfiguration.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/JpaConfiguration.java
@@ -4,10 +4,12 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
 @ComponentScan
 @EnableJpaAuditing
 @EnableAutoConfiguration
+@EnableTransactionManagement
 public class JpaConfiguration {
 }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/ShelterRepository.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/ShelterRepository.java
@@ -12,4 +12,5 @@ public interface ShelterRepository extends JpaRepository<Shelter, Long> {
     List<Shelter> findByTownCode(Long townCode);
     List<Shelter> findByCityName(String cityName);
     List<Shelter> findByTownName(String townName);
+    List<Shelter> findByShelterName(String shelterName);
 }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/BatchType.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/BatchType.java
@@ -1,0 +1,5 @@
+package com.papaolabs.api.infrastructure.persistence.scheduler;
+
+public enum  BatchType {
+    YEAR, MONTH, DAY
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -12,9 +12,7 @@ import com.papaolabs.api.interfaces.v1.dto.type.NeuterType;
 import com.papaolabs.api.interfaces.v1.dto.type.PostType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StopWatch;
 
 import javax.validation.constraints.NotNull;
 import java.text.ParseException;
@@ -24,7 +22,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.lang.Boolean.TRUE;
@@ -62,6 +59,7 @@ public class PostJob {
         this.shelterRepository = shelterRepository;
     }
 
+/*
     @Scheduled(fixedRate = 100000000L)
     public void batch() {
         StopWatch stopWatch = new StopWatch();
@@ -80,6 +78,7 @@ public class PostJob {
                      TimeUnit.MILLISECONDS.toSeconds(stopWatch.getLastTaskTimeMillis()) + "s");
         }
     }
+*/
 
     public void posts(String beginDate, String endDate) {
         String beginDateParam = beginDate;

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -12,7 +12,9 @@ import com.papaolabs.api.interfaces.v1.dto.type.NeuterType;
 import com.papaolabs.api.interfaces.v1.dto.type.PostType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
 
 import javax.validation.constraints.NotNull;
 import java.text.ParseException;
@@ -22,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.lang.Boolean.TRUE;
@@ -59,7 +62,6 @@ public class PostJob {
         this.shelterRepository = shelterRepository;
     }
 
-/*
     @Scheduled(fixedRate = 100000000L)
     public void batch() {
         StopWatch stopWatch = new StopWatch();
@@ -67,7 +69,7 @@ public class PostJob {
         LocalDateTime now;
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
         for (int i = 0; i < yearDays; i++) {
-            now = LocalDateTime.now().minusYears(1)
+            now = LocalDateTime.now().minusYears(5)
                                .minusDays(i);
             stopWatch.start();
             posts(now.format(formatter), now.format(formatter));
@@ -78,7 +80,6 @@ public class PostJob {
                      TimeUnit.MILLISECONDS.toSeconds(stopWatch.getLastTaskTimeMillis()) + "s");
         }
     }
-*/
 
     public void posts(String beginDate, String endDate) {
         String beginDateParam = beginDate;

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -26,7 +26,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -139,7 +138,7 @@ public class PostJob {
                                                });
                                                return x;
                                            })
-                                           .collect(Collectors.toList()););
+                                           .collect(Collectors.toList()));
         } else {
             log.info("PostJob, post not found.. beginDate : {}, endDate : {}", beginDate, endDate);
         }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.Boolean.TRUE;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -122,23 +123,23 @@ public class PostJob {
         if (response != null) {
             List<Post> posts = postRepository.findByHappenDateGreaterThanEqualAndHappenDateLessThanEqual(convertStringToDate(beginDate),
                                                                                                          convertStringToDate(endDate));
-            List<Post> postList = response.getBody()
-                                          .getItems()
-                                          .getItem()
-                                          .stream()
-                                          .map(this::transform)
-                                          .map(x -> {
-                                              posts.forEach(y -> {
-                                                  if (y.getDesertionId()
-                                                       .equals(x.getDesertionId())) {
-                                                      x.setId(y.getId());
-                                                      x.setCreatedDate(y.getCreatedDate());
-                                                  }
-                                              });
-                                              return x;
-                                          })
-                                          .collect(Collectors.toList());
-            postRepository.save(postList);
+            List<AnimalApiResponse.Body.Items.AnimalItemDTO> animalItems = response.getBody()
+                                                                                   .getItems()
+                                                                                   .getItem();
+            log.info("AnimalItemDTO, beginDate : {}, endDate : {}, size : {}", beginDate, endDate, animalItems.size());
+            postRepository.save(animalItems.stream()
+                                           .map(this::transform)
+                                           .map(x -> {
+                                               posts.forEach(y -> {
+                                                   if (y.getDesertionId()
+                                                        .equals(x.getDesertionId())) {
+                                                       x.setId(y.getId());
+                                                       x.setCreatedDate(y.getCreatedDate());
+                                                   }
+                                               });
+                                               return x;
+                                           })
+                                           .collect(Collectors.toList()););
         } else {
             log.info("PostJob, post not found.. beginDate : {}, endDate : {}", beginDate, endDate);
         }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -62,8 +62,7 @@ public class PostJob {
         this.shelterRepository = shelterRepository;
     }
 
-    //    @Scheduled(cron = "0 0 2 1 1/1 ?") // 매달 1일 02시에 실행
-    @Scheduled(fixedRate = 10000000L) // 매달 1일 02시에 실행
+    @Scheduled(cron = "0 0 2 1 1/1 ?") // 매달 1일 02시에 실행
     public void year() {
         for (int i = 0; i < 10; i++) { // 최근 9년간
             batch(BatchType.YEAR, i);

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -68,17 +68,19 @@ public class PostJob {
         Integer yearDays = 365;
         LocalDateTime now;
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
-        for (int i = 0; i < yearDays; i++) {
-            now = LocalDateTime.now()
-                               .minusYears(5)
-                               .minusDays(i);
-            stopWatch.start();
-            posts(now.format(formatter), now.format(formatter));
-            stopWatch.stop();
-            log.info("[batchNo-{}] yyyyMMdd : {}, executionTime : {}",
-                     i,
-                     now.format(formatter),
-                     TimeUnit.MILLISECONDS.toSeconds(stopWatch.getLastTaskTimeMillis()) + "s");
+        for (int i = 6; i < 10; i++) {
+            for (int j = 0; j < yearDays; j++) {
+                now = LocalDateTime.now()
+                                   .minusYears(i)
+                                   .minusDays(j);
+                stopWatch.start();
+                posts(now.format(formatter), now.format(formatter));
+                stopWatch.stop();
+                log.info("[batchNo-{}] yyyyMMdd : {}, executionTime : {}",
+                         j,
+                         now.format(formatter),
+                         TimeUnit.MILLISECONDS.toSeconds(stopWatch.getLastTaskTimeMillis()) + "s");
+            }
         }
     }
 

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -68,7 +68,7 @@ public class PostJob {
         Integer yearDays = 365;
         LocalDateTime now;
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
-        for (int i = 6; i < 10; i++) {
+        for (int i = 8; i < 10; i++) {
             for (int j = 0; j < yearDays; j++) {
                 now = LocalDateTime.now()
                                    .minusYears(i)
@@ -116,7 +116,7 @@ public class PostJob {
                                           .collect(Collectors.toList());
             postRepository.save(postList);
         } else {
-            log.debug("PostJob, post not found.. beginDate : {}, endDate : {}", beginDate, endDate);
+            log.info("PostJob, post not found.. beginDate : {}, endDate : {}", beginDate, endDate);
         }
     }
 

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -12,6 +12,7 @@ import com.papaolabs.api.interfaces.v1.dto.type.NeuterType;
 import com.papaolabs.api.interfaces.v1.dto.type.PostType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
@@ -61,16 +62,15 @@ public class PostJob {
         this.shelterRepository = shelterRepository;
     }
 
-    //@Scheduled(fixedRate = 100000000L)
+    @Scheduled(fixedRate = 100000000L)
     public void batch() {
         StopWatch stopWatch = new StopWatch();
         Integer yearDays = 365;
         LocalDateTime now;
-        DateTimeFormatter formatter;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
         for (int i = 0; i < yearDays; i++) {
-            now = LocalDateTime.now()
+            now = LocalDateTime.now().minusYears(1)
                                .minusDays(i);
-            formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
             stopWatch.start();
             posts(now.format(formatter), now.format(formatter));
             stopWatch.stop();
@@ -176,7 +176,12 @@ public class PostJob {
         post.setOrgCode(String.valueOf(shelter.getTownCode()));
         post.setKindUpCode(String.valueOf(kind.getUpKindCode()));
         post.setKindCode(String.valueOf(kind.getKindCode()));
-        post.setAge(Integer.valueOf(convertAge(animalItemDTO.getAge())));
+        try{
+            post.setAge(Integer.valueOf(convertAge(animalItemDTO.getAge())));
+        }
+        catch (NumberFormatException nfe) {
+            post.setAge(-1);
+        }
         post.setWeight(Float.valueOf(convertWeight(animalItemDTO.getWeight())));
         post.setIntroduction(animalItemDTO.getNoticeComment());
         post.setFeature(animalItemDTO.getSpecialMark());

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -12,9 +12,7 @@ import com.papaolabs.api.interfaces.v1.dto.type.NeuterType;
 import com.papaolabs.api.interfaces.v1.dto.type.PostType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StopWatch;
 
 import javax.validation.constraints.NotNull;
 import java.text.ParseException;
@@ -24,7 +22,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.lang.Boolean.TRUE;
@@ -62,7 +59,7 @@ public class PostJob {
         this.shelterRepository = shelterRepository;
     }
 
-    @Scheduled(fixedRate = 100000000L)
+/*    @Scheduled(fixedRate = 100000000L)
     public void batch() {
         StopWatch stopWatch = new StopWatch();
         Integer yearDays = 365;
@@ -79,7 +76,7 @@ public class PostJob {
                      now.format(formatter),
                      TimeUnit.MILLISECONDS.toSeconds(stopWatch.getLastTaskTimeMillis()) + "s");
         }
-    }
+    }*/
 
     public void posts(String beginDate, String endDate) {
         String beginDateParam = beginDate;

--- a/papao-api/src/main/resources/application.yml
+++ b/papao-api/src/main/resources/application.yml
@@ -10,17 +10,17 @@ spring:
 
 spring.jpa:
   database: MYSQL
-  showSql: true
+  showSql: false
   properties.hibernate.dialect: org.hibernate.dialect.MySQL5InnoDBDialect
   properties.hibernate.hbm2ddl.auto: update
   properties.hibernate.format_sql: true
   properties.hibernate.use_sql_comments: true
 
 logging.level:
-  com.skplanet.rnb: DEBUG
+  com.papaolabs.api: DEBUG
   org.springframework: INFO
-  org.hibernate.SQL: DEBUG
-  org.hibernate.type: TRACE
+  org.hibernate: ERROR
+  org.hibernate.SQL: ERROR
   org.hibernate.type.BasicTypeRegistry: WARN
 
 jasypt:
@@ -38,7 +38,7 @@ spring.profiles: local
 spring:
   jpa:
     database: MYSQL
-    showSql: true
+    showSql: false
     properties.hibernate.dialect: org.hibernate.dialect.MySQL5InnoDBDialect
     properties.hibernate.hbm2ddl.auto: create-drop
     properties.hibernate.format_sql: true

--- a/papao-api/src/main/resources/application.yml
+++ b/papao-api/src/main/resources/application.yml
@@ -55,12 +55,9 @@ spring.datasource:
   password: ENC(bHUKdWgtyhtWbjW9mPOGRg==)
   driverClassName: com.mysql.jdbc.Driver
   initialize: false
-  ## Pool Info ##
-  maxActive: 100
-  initialSize: 10
-  minIdle: 10
-  validationQuery: select 1
-  testWhileIdle: true
-  timeBetweenEvictionRunsMillis: 5000 #5 second
-  minEvictableIdleTimeMillis: 10000  #10 second
-  validationQueryTimeout: 5
+  connection-test-query: SELECT 1
+  test-while-idle: true
+  test-on-borrow: true
+  validation-interval: 10000
+  log-validation-errors: true
+  validation-query: SELECT 1

--- a/papao-api/src/main/resources/templates/pages/detail.ftl
+++ b/papao-api/src/main/resources/templates/pages/detail.ftl
@@ -149,7 +149,7 @@
                     View Updates
                 </a>-->
                     <span class="mdl-list__item-primary-content">
-                                <form action="/dashboard/comment?postId=${post.id}" method="post">
+                                <form action="/dashboard/comment?postId=${post.id?c}" method="post">
                                   <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label"
                                        style="width:100% !important;">
                                     <input class="mdl-textfield__input" type="text" name="text">

--- a/papao-api/src/main/resources/templates/pages/index.ftl
+++ b/papao-api/src/main/resources/templates/pages/index.ftl
@@ -137,7 +137,7 @@
                 </div>
                 <div class="mdl-card__actions mdl-card--border">
                     <a class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect mdl-button--accent"
-                       href="/dashboard/detail?pageId=${post.id}">Read more</a>
+                       href="/dashboard/detail?pageId=${post.id?c}">Read more</a>
                 </div>
             </div>
         </#list>


### PR DESCRIPTION
### Updates
* 변경된 배치 정책 반영 (일부 우선 임의로 적용) #46 
* 배치 관련 로직 변경
* 크론탭 방식으로 변경

### Description
* 기존 일 단위로 끊어서 API 콜 -> 가공 -> DB INSERT 에서 1년 단위 데이터를 일괄적으로 가져와서 한번에 처리하도록 함, 돌려보면서 문제가 생길 경우 해결 해야할듯.. 기존엔 connection 끊기는 상황이 많아서 문제가 잦았던 편이라 이 방식이 더 나을것 같음
* 보통 년간 데이터가 80000개 수준, 이를 처리하는데 걸리는 시간은 5분정도임, 2008년 기준으로 현재 데이터까지 가공하도록 함

### How to Test
```
BRANCH=feature/PAPAOAPI-54; git fetch origin $BRANCH && git checkout $BRANCH &&  git pull && ./gradlew clean test
```

### Note
* 데이터 스키마 재정의 및 전체적인 배치 작업 필요 -> 몇년부터 할것인지?? 우선 다 진행 해보도록 하겠음