### PR TITLE
#74 google vision api 연동

### DIFF
--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionColor.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionColor.java
@@ -1,0 +1,36 @@
+package com.papaolabs.api.domain.model;
+
+import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+@Data
+@Entity
+@EntityListeners(value = {AuditingEntityListener.class })
+@Table(name = "VISION_COLOR_TB")
+public class VisionColor {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private Integer red;
+    private Integer green;
+    private Integer blue;
+    private Double score;
+    @Column(name = "PIXEL_FRACTION")
+    private Double pixelFraction;
+    @Column(name = "CREATED_DATE")
+    @CreatedDate
+    private Date createdDate;
+    @Column(name = "UPDATED_DATE")
+    @LastModifiedDate
+    private Date updatedDate;
+}

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionColor.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionColor.java
@@ -23,6 +23,8 @@ public class VisionColor {
     private Long id;
     @Column(name = "POST_ID")
     private Long postId;
+    @Column(name = "IMAGE_URL")
+    private String imageUrl;
     private Integer red;
     private Integer green;
     private Integer blue;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionColor.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionColor.java
@@ -21,6 +21,8 @@ public class VisionColor {
     @Id
     @GeneratedValue
     private Long id;
+    @Column(name = "POST_ID")
+    private Long postId;
     private Integer red;
     private Integer green;
     private Integer blue;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
@@ -21,6 +21,7 @@ public class VisionLabel {
     @Id
     @GeneratedValue
     private Long id;
+    private String pid;
     private String mid;
     private String name;
     private Double score;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
@@ -1,0 +1,33 @@
+package com.papaolabs.api.domain.model;
+
+import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+@Data
+@Entity
+@EntityListeners(value = {AuditingEntityListener.class })
+@Table(name = "VISION_LABEL_TB")
+public class VisionLabel {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private Integer key;
+    private String name;
+    private Double score;
+    @Column(name = "CREATED_DATE")
+    @CreatedDate
+    private Date createdDate;
+    @Column(name = "UPDATED_DATE")
+    @LastModifiedDate
+    private Date updatedDate;
+}

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
@@ -23,6 +23,8 @@ public class VisionLabel {
     private Long id;
     @Column(name = "POST_ID")
     private Long postId;
+    @Column(name = "IMAGE_URL")
+    private String imageUrl;
     private String mid;
     private String name;
     private Double score;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
@@ -21,7 +21,8 @@ public class VisionLabel {
     @Id
     @GeneratedValue
     private Long id;
-    private String pid;
+    @Column(name = "POST_ID")
+    private Long postId;
     private String mid;
     private String name;
     private Double score;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionLabel.java
@@ -21,7 +21,7 @@ public class VisionLabel {
     @Id
     @GeneratedValue
     private Long id;
-    private Integer key;
+    private String mid;
     private String name;
     private Double score;
     @Column(name = "CREATED_DATE")

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionType.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionType.java
@@ -1,0 +1,34 @@
+package com.papaolabs.api.domain.model;
+
+import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Date;
+
+@Data
+@Entity
+@EntityListeners(value = {AuditingEntityListener.class })
+@Table(name = "VISION_TYPE_TB")
+public class VisionType {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String adult;
+    private String spoof;
+    private String medical;
+    private String violence;
+    @Column(name = "CREATED_DATE")
+    @CreatedDate
+    private Date createdDate;
+    @Column(name = "UPDATED_DATE")
+    @LastModifiedDate
+    private Date updatedDate;
+}

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionType.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionType.java
@@ -21,6 +21,8 @@ public class VisionType {
     @Id
     @GeneratedValue
     private Long id;
+    @Column(name = "POST_ID")
+    private Long postId;
     private String adult;
     private String spoof;
     private String medical;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionType.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/model/VisionType.java
@@ -23,6 +23,8 @@ public class VisionType {
     private Long id;
     @Column(name = "POST_ID")
     private Long postId;
+    @Column(name = "IMAGE_URL")
+    private String imageUrl;
     private String adult;
     private String spoof;
     private String medical;

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/BatchService.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/BatchService.java
@@ -1,0 +1,4 @@
+package com.papaolabs.api.domain.service;
+
+public interface BatchService {
+}

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/PostService.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/PostService.java
@@ -37,4 +37,6 @@ public interface PostService {
     PostDTO delete(String id);
 
     PostDTO setState(String postId, StateType state);
+
+    void syncPosts(String beginDate, String endDate);
 }

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/PostServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/PostServiceImpl.java
@@ -1,14 +1,21 @@
 package com.papaolabs.api.domain.service;
 
+import com.papaolabs.api.domain.model.Kind;
 import com.papaolabs.api.domain.model.Post;
+import com.papaolabs.api.domain.model.Shelter;
 import com.papaolabs.api.infrastructure.persistence.jpa.repository.KindRepository;
 import com.papaolabs.api.infrastructure.persistence.jpa.repository.PostRepository;
+import com.papaolabs.api.infrastructure.persistence.jpa.repository.ShelterRepository;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.AnimalApiClient;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.AnimalApiResponse;
 import com.papaolabs.api.interfaces.v1.dto.PostDTO;
 import com.papaolabs.api.interfaces.v1.dto.type.GenderType;
 import com.papaolabs.api.interfaces.v1.dto.type.NeuterType;
+import com.papaolabs.api.interfaces.v1.dto.type.PostType;
 import com.papaolabs.api.interfaces.v1.dto.type.StateType;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,10 +28,14 @@ import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.SPACE;
+import static org.apache.commons.lang3.StringUtils.isAllBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -32,16 +43,29 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 @Service
 @Transactional
 public class PostServiceImpl implements PostService {
+    private static final String MAX_SIZE = "500000";
+    private static final String START_INDEX = "1";
+    @Value("${seoul.api.animal.appKey}")
+    private String appKey;
     private static final String UNKNOWN = "UNKNOWN";
     private static final String DATE_FORMAT = "yyyyMMdd";
+    @NotNull
+    private final AnimalApiClient animalApiClient;
     @NotNull
     private final PostRepository postRepository;
     @NotNull
     private final KindRepository kindRepository;
+    @NotNull
+    private final ShelterRepository shelterRepository;
 
-    public PostServiceImpl(PostRepository postRepository, KindRepository kindRepository) {
+    public PostServiceImpl(AnimalApiClient animalApiClient,
+                           PostRepository postRepository,
+                           KindRepository kindRepository,
+                           ShelterRepository shelterRepository) {
+        this.animalApiClient = animalApiClient;
         this.postRepository = postRepository;
         this.kindRepository = kindRepository;
+        this.shelterRepository = shelterRepository;
     }
 
     @Override
@@ -149,6 +173,108 @@ public class PostServiceImpl implements PostService {
         return transform(post);
     }
 
+    public void syncPosts(String beginDate, String endDate) {
+        String beginDateParam = beginDate;
+        String endDateParam = endDate;
+        if (isEmpty(beginDate)) {
+            beginDateParam = getDefaultDate(DATE_FORMAT);
+        }
+        if (isEmpty(endDate)) {
+            endDateParam = getDefaultDate(DATE_FORMAT);
+        }
+        AnimalApiResponse response = animalApiClient.animal(appKey, beginDateParam, endDateParam, EMPTY, EMPTY,
+                                                            EMPTY, EMPTY, EMPTY, EMPTY, START_INDEX, MAX_SIZE);
+        if (response != null) {
+            List<Post> posts = postRepository.findByHappenDateGreaterThanEqualAndHappenDateLessThanEqual(convertStringToDate(beginDate),
+                                                                                                         convertStringToDate(endDate));
+            List<AnimalApiResponse.Body.Items.AnimalItemDTO> animalItems = response.getBody()
+                                                                                   .getItems()
+                                                                                   .getItem();
+            log.info("AnimalItemDTO, beginDate : {}, endDate : {}, size : {}", beginDate, endDate, animalItems.size());
+            postRepository.save(animalItems.stream()
+                                           .map(this::transform)
+                                           .map(x -> {
+                                               posts.forEach(y -> {
+                                                   if (y.getDesertionId()
+                                                        .equals(x.getDesertionId())) {
+                                                       x.setId(y.getId());
+                                                       x.setCreatedDate(y.getCreatedDate());
+                                                   }
+                                               });
+                                               return x;
+                                           })
+                                           .collect(Collectors.toList()));
+        } else {
+            log.info("PostJob, post not found.. beginDate : {}, endDate : {}", beginDate, endDate);
+        }
+    }
+
+    private Post transform(AnimalApiResponse.Body.Items.AnimalItemDTO animalItemDTO) {
+        String kindName = convertKindName(animalItemDTO.getKindCd());
+        Kind mockKind = new Kind();
+        mockKind.setUpKindCode(-1L);
+        mockKind.setKindCode(-1L);
+        Kind kind = Optional.ofNullable(kindRepository.findByKindName(kindName))
+                            .orElse(mockKind);
+        String[] orgNames = animalItemDTO.getOrgNm()
+                                         .split(SPACE);
+        Shelter mockShelter = new Shelter();
+        mockShelter.setCityCode(-1L);
+        mockShelter.setCityName(UNKNOWN);
+        mockShelter.setTownCode(-1L);
+        mockShelter.setTownName(UNKNOWN);
+        mockShelter.setShelterCode(-1L);
+        mockShelter.setShelterName(UNKNOWN);
+        Shelter shelter = new Shelter();
+        switch (orgNames.length) {
+            case 1:
+                shelter = shelterRepository.findByCityName(orgNames[0])
+                                           .stream()
+                                           .findFirst()
+                                           .orElse(mockShelter);
+                break;
+            case 2:
+                shelter = shelterRepository.findByTownName(orgNames[1])
+                                           .stream()
+                                           .findFirst()
+                                           .orElse(mockShelter);
+                break;
+        }
+        if ("-1".equals(shelter.getTownCode())) {
+            shelter = shelterRepository.findByShelterName(animalItemDTO.getCareNm())
+                                       .stream()
+                                       .findFirst()
+                                       .orElse(mockShelter);
+        }
+        Post post = new Post();
+        post.setDesertionId(Long.valueOf(animalItemDTO.getDesertionNo()));
+        post.setImageUrl(animalItemDTO.getPopfile());
+        post.setType(PostType.SYSTEM.getCode());
+        post.setState(animalItemDTO.getProcessState());
+        post.setGender(animalItemDTO.getSexCd());
+        post.setNeuter(isEmpty(animalItemDTO.getNeuterYn()) ? NeuterType.U.name() : animalItemDTO.getNeuterYn());
+        post.setUserId(PostType.SYSTEM.getCode());
+        post.setUserName(animalItemDTO.getCareNm());
+        post.setUserAddress(animalItemDTO.getCareAddr());
+        post.setUserContact(animalItemDTO.getCareTel());
+        post.setHappenDate(convertStringToDate(animalItemDTO.getHappenDt()));
+        post.setHappenPlace(isNotEmpty(animalItemDTO.getOrgNm()) ? animalItemDTO.getOrgNm() : UNKNOWN);
+        post.setUprCode(String.valueOf(shelter.getCityCode()));
+        post.setOrgCode(String.valueOf(shelter.getTownCode()));
+        post.setKindUpCode(String.valueOf(kind.getUpKindCode()));
+        post.setKindCode(String.valueOf(kind.getKindCode()));
+        try {
+            post.setAge(Integer.valueOf(convertAge(animalItemDTO.getAge())));
+        } catch (NumberFormatException nfe) {
+            post.setAge(-1);
+        }
+        post.setWeight(Float.valueOf(convertWeight(animalItemDTO.getWeight())));
+        post.setIntroduction(animalItemDTO.getNoticeComment());
+        post.setFeature(animalItemDTO.getSpecialMark());
+        post.setIsDisplay(TRUE);
+        return post;
+    }
+
     private PostDTO transform(Post post) {
         return PostDTO.builder()
                       .id(post.getId())
@@ -206,5 +332,31 @@ public class PostServiceImpl implements PostService {
             e.printStackTrace();
         }
         return new Date();
+    }
+
+    private String convertWeight(String weight) {
+        if (isEmpty(weight)) {
+            return "-1";
+        }
+        if (weight.contains("(Kg)")) {
+            weight = weight.replace("(Kg)", "");
+            try {
+                Float.valueOf(weight);
+            } catch (NumberFormatException nfe) {
+                weight = "-1";
+            }
+        }
+        return weight;
+    }
+
+    private String convertAge(String age) {
+        String result = age.replace(" ", "");
+        if (isEmpty(result) || isAllBlank(result)) {
+            return "-1";
+        }
+        if (result.contains("(년생)")) {
+            return result.replace("(년생)", "");
+        }
+        return result;
     }
 }

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionService.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionService.java
@@ -1,7 +1,7 @@
 package com.papaolabs.api.domain.service;
 
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse;
+import com.papaolabs.api.interfaces.v1.dto.PostDTO;
 
 public interface VisionService {
-    void create(VisionApiResponse response);
+    void syncVisionData(PostDTO post);
 }

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionService.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionService.java
@@ -2,6 +2,9 @@ package com.papaolabs.api.domain.service;
 
 import com.papaolabs.api.interfaces.v1.dto.PostDTO;
 
+import java.util.List;
+
 public interface VisionService {
     void syncVisionData(PostDTO post);
+    void syncVisionData(List<PostDTO> posts);
 }

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionService.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionService.java
@@ -1,0 +1,7 @@
+package com.papaolabs.api.domain.service;
+
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse;
+
+public interface VisionService {
+    void create(VisionApiResponse response);
+}

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionServiceImpl.java
@@ -1,0 +1,81 @@
+package com.papaolabs.api.domain.service;
+
+import com.papaolabs.api.domain.model.VisionColor;
+import com.papaolabs.api.domain.model.VisionLabel;
+import com.papaolabs.api.domain.model.VisionType;
+import com.papaolabs.api.infrastructure.persistence.jpa.repository.VisionColorRepository;
+import com.papaolabs.api.infrastructure.persistence.jpa.repository.VisionLabelRepository;
+import com.papaolabs.api.infrastructure.persistence.jpa.repository.VisionTypeRepository;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult.Label;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult.Type;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult.VisionProperties.DominantColor.Color;
+import org.springframework.stereotype.Service;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class VisionServiceImpl implements VisionService {
+    @NotNull
+    private final VisionLabelRepository labelRepository;
+    @NotNull
+    private final VisionColorRepository colorRepository;
+    @NotNull
+    private final VisionTypeRepository typeRepository;
+
+    public VisionServiceImpl(VisionLabelRepository labelRepository,
+                             VisionColorRepository colorRepository,
+                             VisionTypeRepository typeRepository) {
+        this.labelRepository = labelRepository;
+        this.colorRepository = colorRepository;
+        this.typeRepository = typeRepository;
+    }
+
+    @Override
+    public void create(VisionApiResponse response) {
+        List<VisionResult> visionResults = response.getResponses();
+        for (VisionResult visionResult : visionResults) {
+            labelRepository.save(visionResult.getLabelAnnotations()
+                                             .stream()
+                                             .map(this::transform)
+                                             .collect(Collectors.toList()));
+            typeRepository.save(transform(visionResult.getSafeSearchAnnotation()));
+            colorRepository.save(visionResult.getImagePropertiesAnnotation()
+                                             .getDominantColors()
+                                             .getColors()
+                                             .stream()
+                                             .map(this::transform)
+                                             .collect(Collectors.toList()));
+        }
+    }
+
+    private VisionLabel transform(Label label) {
+        VisionLabel visionLabel = new VisionLabel();
+        visionLabel.setMid(label.getMid());
+        visionLabel.setName(label.getDescription());
+        visionLabel.setScore(label.getScore());
+        return visionLabel;
+    }
+
+    private VisionColor transform(Color color) {
+        VisionColor visionColor = new VisionColor();
+        visionColor.setRed(color.getRed());
+        visionColor.setGreen(color.getGreen());
+        visionColor.setBlue(color.getBlue());
+        visionColor.setScore(color.getScore());
+        visionColor.setPixelFraction(color.getPixelFraction());
+        return visionColor;
+    }
+
+    private VisionType transform(Type type) {
+        VisionType visionType = new VisionType();
+        visionType.setAdult(type.getAdult());
+        visionType.setSpoof(type.getSpoof());
+        visionType.setMedical(type.getMedical());
+        visionType.setViolence(type.getViolence());
+        return visionType;
+    }
+}

--- a/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionServiceImpl.java
+++ b/papao-api/src/main/java/com/papaolabs/api/domain/service/VisionServiceImpl.java
@@ -6,15 +6,20 @@ import com.papaolabs.api.domain.model.VisionType;
 import com.papaolabs.api.infrastructure.persistence.jpa.repository.VisionColorRepository;
 import com.papaolabs.api.infrastructure.persistence.jpa.repository.VisionLabelRepository;
 import com.papaolabs.api.infrastructure.persistence.jpa.repository.VisionTypeRepository;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.VisionApiClient;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiRequest;
 import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse;
 import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult;
 import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult.Label;
 import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult.Type;
 import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse.VisionResult.VisionProperties.DominantColor
     .Properties;
+import com.papaolabs.api.interfaces.v1.dto.PostDTO;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,11 +27,20 @@ import java.util.stream.Collectors;
 @Service
 public class VisionServiceImpl implements VisionService {
     public static final List<String> filterNameList = Arrays.asList("dog",
+                                                                    "dorgi",
+                                                                    "paw",
+                                                                    "fur",
+                                                                    "snout",
                                                                     "dog breed",
                                                                     "dog like mammal",
                                                                     "dog breed group",
+                                                                    "cat like mammal",
                                                                     "mammal",
                                                                     "vertebrate");
+    @Value("${google.application.key}")
+    private String visionAppKey;
+    @NotNull
+    private final VisionApiClient visionApiClient;
     @NotNull
     private final VisionLabelRepository labelRepository;
     @NotNull
@@ -34,41 +48,54 @@ public class VisionServiceImpl implements VisionService {
     @NotNull
     private final VisionTypeRepository typeRepository;
 
-    public VisionServiceImpl(VisionLabelRepository labelRepository,
+    public VisionServiceImpl(VisionApiClient visionApiClient, VisionLabelRepository labelRepository,
                              VisionColorRepository colorRepository,
                              VisionTypeRepository typeRepository) {
+        this.visionApiClient = visionApiClient;
         this.labelRepository = labelRepository;
         this.colorRepository = colorRepository;
         this.typeRepository = typeRepository;
     }
 
     @Override
-    public void create(VisionApiResponse response) {
-        List<VisionResult> visionResults = response.getResponses();
+    public void syncVisionData(PostDTO post) {
+        VisionApiResponse result = visionApiClient.image(visionAppKey,
+                                                         createVisionApiRequest(
+                                                             post.getImageUrl()));
+        List<VisionResult> visionResults = result.getResponses();
         for (VisionResult visionResult : visionResults) {
             labelRepository.save(visionResult.getLabelAnnotations()
                                              .stream()
                                              .filter(x -> filterLabelName(x.getDescription()))
                                              .map(this::transform)
+                                             .map(x -> {
+                                                 x.setPostId(post.getId());
+                                                 return x;
+                                             })
                                              .collect(Collectors.toList()));
-            typeRepository.save(transform(visionResult.getSafeSearchAnnotation()));
+            VisionType visionType = transform(visionResult.getSafeSearchAnnotation());
+            visionType.setPostId(post.getId());
+            typeRepository.save(visionType);
             colorRepository.save(visionResult.getImagePropertiesAnnotation()
                                              .getDominantColors()
                                              .getColors()
                                              .stream()
                                              .map(this::transform)
+                                             .map(x -> {
+                                                 x.setPostId(post.getId());
+                                                 return x;
+                                             })
                                              .collect(Collectors.toList()));
         }
     }
 
     private Boolean filterLabelName(String name) {
         return !filterNameList.stream()
-                             .anyMatch(x -> x.equals(name));
+                              .anyMatch(x -> x.equals(name));
     }
 
     private VisionLabel transform(Label label) {
         VisionLabel visionLabel = new VisionLabel();
-        visionLabel.setPid("-1");
         visionLabel.setMid(label.getMid());
         visionLabel.setName(label.getDescription());
         visionLabel.setScore(label.getScore());
@@ -95,5 +122,37 @@ public class VisionServiceImpl implements VisionService {
         visionType.setMedical(type.getMedical());
         visionType.setViolence(type.getViolence());
         return visionType;
+    }
+
+    private VisionApiRequest createVisionApiRequest(String imageUrl) {
+        List<VisionApiRequest.Request> requests = new ArrayList<>();
+        List<VisionApiRequest.Request.Feature> features = new ArrayList<>();
+        features.add(VisionApiRequest.Request.Feature.builder()
+                                                     .type("LABEL_DETECTION")
+                                                     .build());
+/*        features.add(Feature.builder()
+                            .type("FACE_DETECTION")
+                            .build());*/
+        features.add(VisionApiRequest.Request.Feature.builder()
+                                                     .type("IMAGE_PROPERTIES")
+                                                     .build());
+        features.add(VisionApiRequest.Request.Feature.builder()
+                                                     .type("SAFE_SEARCH_DETECTION")
+                                                     .build());
+/*        features.add(Feature.builder()
+                            .type("CROP_HINTS")
+                            .build());*/
+        requests.add(VisionApiRequest.Request.builder()
+                                             .image(VisionApiRequest.Request.Image.builder()
+                                                                                  .source(VisionApiRequest.Request.Image.Source.builder()
+                                                                                                                               .imageUri(
+                                                                                                                                   imageUrl)
+                                                                                                                               .build())
+                                                                                  .build())
+                                             .features(features)
+                                             .build());
+        return VisionApiRequest.builder()
+                               .requests(requests)
+                               .build();
     }
 }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/VisionColorRepository.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/VisionColorRepository.java
@@ -1,0 +1,7 @@
+package com.papaolabs.api.infrastructure.persistence.jpa.repository;
+
+import com.papaolabs.api.domain.model.VisionColor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisionColorRepository extends JpaRepository<VisionColor, Long> {
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/VisionLabelRepository.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/VisionLabelRepository.java
@@ -1,0 +1,7 @@
+package com.papaolabs.api.infrastructure.persistence.jpa.repository;
+
+import com.papaolabs.api.domain.model.VisionLabel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisionLabelRepository extends JpaRepository<VisionLabel, Long> {
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/VisionTypeRepository.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/jpa/repository/VisionTypeRepository.java
@@ -1,0 +1,7 @@
+package com.papaolabs.api.infrastructure.persistence.jpa.repository;
+
+import com.papaolabs.api.domain.model.VisionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisionTypeRepository extends JpaRepository<VisionType, Long> {
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/VisionApiConfig.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/VisionApiConfig.java
@@ -1,0 +1,31 @@
+package com.papaolabs.api.infrastructure.persistence.restapi;
+
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.VisionApiClient;
+import feign.Feign;
+import feign.Logger;
+import feign.gson.GsonDecoder;
+import feign.gson.GsonEncoder;
+import feign.okhttp.OkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan
+@EnableAutoConfiguration
+public class VisionApiConfig {
+    @Value("${google.application.imageUrl}")
+    private String visionApiUrl;
+
+    @Bean
+    public VisionApiClient visionApiClient() {
+        return Feign.builder()
+                    .client(new OkHttpClient())
+                    .encoder(new GsonEncoder())
+                    .decoder(new GsonDecoder())
+                    .logLevel(Logger.Level.FULL)
+                    .target(VisionApiClient.class, visionApiUrl);
+    }
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/VisionApiClient.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/VisionApiClient.java
@@ -1,0 +1,16 @@
+package com.papaolabs.api.infrastructure.persistence.restapi.feign;
+
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiRequest;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import org.springframework.cloud.netflix.feign.FeignClient;
+
+@FeignClient(name = "visionApiClient", fallbackFactory = VisionApiClientFallbackFactory.class)
+public interface VisionApiClient {
+
+    @Headers("Content-Type: application/json")
+    @RequestLine("POST /images:annotate?key={key}")
+    VisionApiResponse image(@Param(value = "key") String key, VisionApiRequest request);
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/VisionApiClientFallbackFactory.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/VisionApiClientFallbackFactory.java
@@ -25,8 +25,8 @@ public class VisionApiClientFallbackFactory implements LoggingFallbackFactory<Vi
 
     public static class VisionApiFallback implements VisionApiClient {
         @Override
-        public VisionApiResponse image(@Param(value = "key") String serviceKey, @RequestBody VisionApiRequest request) {
-            log.debug("service key : {}, request : {}", serviceKey, request.toString());
+        public VisionApiResponse image(@Param(value = "mid") String serviceKey, @RequestBody VisionApiRequest request) {
+            log.debug("service mid : {}, request : {}", serviceKey, request.toString());
             return new VisionApiResponse();
         }
     }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/VisionApiClientFallbackFactory.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/VisionApiClientFallbackFactory.java
@@ -1,0 +1,33 @@
+package com.papaolabs.api.infrastructure.persistence.restapi.feign;
+
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiRequest;
+import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse;
+import feign.Param;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Component
+@Slf4j
+public class VisionApiClientFallbackFactory implements LoggingFallbackFactory<VisionApiClient> {
+    private static final VisionApiClient FALLBACK = new VisionApiFallback();
+
+    @Override
+    public VisionApiClient fallback() {
+        return FALLBACK;
+    }
+
+    @Override
+    public Logger logger() {
+        return null;
+    }
+
+    public static class VisionApiFallback implements VisionApiClient {
+        @Override
+        public VisionApiResponse image(@Param(value = "key") String serviceKey, @RequestBody VisionApiRequest request) {
+            log.debug("service key : {}, request : {}", serviceKey, request.toString());
+            return new VisionApiResponse();
+        }
+    }
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiRequest.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiRequest.java
@@ -29,15 +29,7 @@ public class VisionApiRequest implements Serializable{
         @NoArgsConstructor
         @AllArgsConstructor
         public static class Image {
-            private Source source;
-
-            @Data
-            @Builder
-            @NoArgsConstructor
-            @AllArgsConstructor
-            public static class Source {
-                private String imageUri;
-            }
+            private String content;
         }
 
         @Data

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiRequest.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiRequest.java
@@ -1,0 +1,51 @@
+package com.papaolabs.api.infrastructure.persistence.restapi.feign.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class VisionApiRequest implements Serializable{
+    private static final long serialVersionUID = 2222381080708745408L;
+    private List<Request> requests;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Request {
+        private Image image;
+        private List<Feature> features;
+
+        @Data
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Image {
+            private Source source;
+
+            @Data
+            @Builder
+            @NoArgsConstructor
+            @AllArgsConstructor
+            public static class Source {
+                private String imageUri;
+            }
+        }
+
+        @Data
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class Feature {
+            private String type;
+        }
+    }
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
@@ -1,0 +1,46 @@
+package com.papaolabs.api.infrastructure.persistence.restapi.feign.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class VisionApiResponse {
+    private List<VisionResult> responses;
+
+    @Data
+    public static class VisionResult {
+        private List<Label> labelAnnotations;
+        private Type safeSearchAnnotation;
+        private List<DominantColor> dominantColors;
+
+        @Data
+        public static class Label {
+            private String mid;
+            private String description;
+            private Double score;
+        }
+
+        @Data
+        public static class DominantColor {
+            private List<Color> colors;
+            private Double score;
+            private Double pixelFraction;
+
+            @Data
+            public static class Color {
+                private Integer red;
+                private Integer green;
+                private Integer blue;
+            }
+        }
+
+        @Data
+        public static class Type {
+            private String adult;
+            private String spoof;
+            private String medical;
+            private String violence;
+        }
+    }
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
@@ -9,7 +9,7 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Data
 public class VisionApiResponse {
-    private List<VisionResult> responses;
+    private List<VisionResult> responses = Arrays.asList();
 
     @Data
     public static class VisionResult {

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
@@ -2,7 +2,10 @@ package com.papaolabs.api.infrastructure.persistence.restapi.feign.dto;
 
 import lombok.Data;
 
+import java.util.Arrays;
 import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Data
 public class VisionApiResponse {
@@ -10,36 +13,36 @@ public class VisionApiResponse {
 
     @Data
     public static class VisionResult {
-        private List<Label> labelAnnotations;
-        private Type safeSearchAnnotation;
-        private VisionProperties imagePropertiesAnnotation;
+        private List<Label> labelAnnotations = Arrays.asList();
+        private Type safeSearchAnnotation = new Type();
+        private VisionProperties imagePropertiesAnnotation = new VisionProperties();
 
         @Data
         public static class Label {
-            private String mid;
-            private String description;
-            private Double score;
+            private String mid = EMPTY;
+            private String description = EMPTY;
+            private Double score = -1.0;
         }
 
         @Data
         public static class VisionProperties {
-            private DominantColor dominantColors;
+            private DominantColor dominantColors = new DominantColor();
 
             @Data
             public static class DominantColor {
-                List<Properties> colors;
+                List<Properties> colors = Arrays.asList();
 
                 @Data
                 public static class Properties {
-                    private Color color;
-                    private Double score;
-                    private Double pixelFraction;
+                    private Color color = new Color();
+                    private Double score = -1.0;
+                    private Double pixelFraction = -1.0;
 
                     @Data
                     public static class Color {
-                        private Integer red;
-                        private Integer green;
-                        private Integer blue;
+                        private Integer red = -1;
+                        private Integer green = -1;
+                        private Integer blue = -1;
                     }
                 }
             }
@@ -47,10 +50,10 @@ public class VisionApiResponse {
 
         @Data
         public static class Type {
-            private String adult;
-            private String spoof;
-            private String medical;
-            private String violence;
+            private String adult = EMPTY;
+            private String spoof = EMPTY;
+            private String medical = EMPTY;
+            private String violence = EMPTY;
         }
     }
 }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
@@ -27,15 +27,20 @@ public class VisionApiResponse {
 
             @Data
             public static class DominantColor {
-                List<Color> colors;
+                List<Properties> colors;
 
                 @Data
-                public static class Color {
-                    private Integer red;
-                    private Integer green;
-                    private Integer blue;
+                public static class Properties {
+                    private Color color;
                     private Double score;
                     private Double pixelFraction;
+
+                    @Data
+                    public static class Color {
+                        private Integer red;
+                        private Integer green;
+                        private Integer blue;
+                    }
                 }
             }
         }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionApiResponse.java
@@ -12,7 +12,7 @@ public class VisionApiResponse {
     public static class VisionResult {
         private List<Label> labelAnnotations;
         private Type safeSearchAnnotation;
-        private List<DominantColor> dominantColors;
+        private VisionProperties imagePropertiesAnnotation;
 
         @Data
         public static class Label {
@@ -22,16 +22,21 @@ public class VisionApiResponse {
         }
 
         @Data
-        public static class DominantColor {
-            private List<Color> colors;
-            private Double score;
-            private Double pixelFraction;
+        public static class VisionProperties {
+            private DominantColor dominantColors;
 
             @Data
-            public static class Color {
-                private Integer red;
-                private Integer green;
-                private Integer blue;
+            public static class DominantColor {
+                List<Color> colors;
+
+                @Data
+                public static class Color {
+                    private Integer red;
+                    private Integer green;
+                    private Integer blue;
+                    private Double score;
+                    private Double pixelFraction;
+                }
             }
         }
 

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionColorResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionColorResponse.java
@@ -1,0 +1,17 @@
+package com.papaolabs.api.infrastructure.persistence.restapi.feign.dto;
+
+import lombok.Data;
+
+@Data
+public class VisionColorResponse {
+    private String RgbCode;
+    private Double score;
+    private Double pixelFraction;
+    
+    @Data
+    public static class RgbColor {
+        private Integer red;
+        private Integer green;
+        private Integer blue;
+    }
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionLabelResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionLabelResponse.java
@@ -1,0 +1,10 @@
+package com.papaolabs.api.infrastructure.persistence.restapi.feign.dto;
+
+import lombok.Data;
+
+@Data
+public class VisionLabelResponse {
+    private String mid;
+    private String description;
+    private Double score;
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionTypeResponse.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/restapi/feign/dto/VisionTypeResponse.java
@@ -1,0 +1,11 @@
+package com.papaolabs.api.infrastructure.persistence.restapi.feign.dto;
+
+import lombok.Data;
+
+@Data
+public class VisionTypeResponse {
+    private String adult;
+    private String spoof;
+    private String medical;
+    private String violence;
+}

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -37,7 +37,7 @@ public class PostJob {
         String nowDate = LocalDateTime.now()
                                       .format(formatter);
         stopWatch.start();
-        List<PostDTO> posts = postService.readPosts(nowDate, nowDate, EMPTY, EMPTY, EMPTY, "1", "10");
+        List<PostDTO> posts = postService.readPosts(nowDate, nowDate, EMPTY, EMPTY, EMPTY, "1", "1");
         for (PostDTO post : posts) {
             visionService.syncVisionData(post);
         }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -41,6 +41,7 @@ public class PostJob {
         for (PostDTO post : posts) {
             visionService.syncVisionData(post);
         }
+//        visionService.syncVisionData(posts);
         stopWatch.stop();
         log.debug("[GOOGLE_VISION_COMPLETE] executionTime : {} millis", stopWatch.getLastTaskTimeMillis());
     }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -1,91 +1,48 @@
 package com.papaolabs.api.infrastructure.persistence.scheduler;
 
-import com.google.gson.Gson;
-import com.papaolabs.api.domain.model.Kind;
-import com.papaolabs.api.domain.model.Post;
-import com.papaolabs.api.domain.model.Shelter;
+import com.papaolabs.api.domain.service.PostService;
 import com.papaolabs.api.domain.service.VisionService;
-import com.papaolabs.api.infrastructure.persistence.jpa.repository.KindRepository;
-import com.papaolabs.api.infrastructure.persistence.jpa.repository.PostRepository;
-import com.papaolabs.api.infrastructure.persistence.jpa.repository.ShelterRepository;
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.AnimalApiClient;
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.VisionApiClient;
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.AnimalApiResponse;
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiRequest;
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiRequest.Request;
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiRequest.Request.Feature;
-import com.papaolabs.api.infrastructure.persistence.restapi.feign.dto.VisionApiResponse;
-import com.papaolabs.api.interfaces.v1.dto.type.NeuterType;
-import com.papaolabs.api.interfaces.v1.dto.type.PostType;
+import com.papaolabs.api.interfaces.v1.dto.PostDTO;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
 import javax.validation.constraints.NotNull;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-import static java.lang.Boolean.TRUE;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.apache.commons.lang3.StringUtils.SPACE;
-import static org.apache.commons.lang3.StringUtils.isAllBlank;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang.StringUtils.EMPTY;
 
 @Slf4j
 @Component
 public class PostJob {
-    private static final String UNKNOWN = "UNKNOWN";
-    private static final String DATE_FORMAT = "yyyyMMdd";
-    private static final String MAX_SIZE = "500000";
-    private static final String START_INDEX = "1";
-    @Value("${seoul.api.animal.appKey}")
-    private String appKey;
-    @Value("${google.application.key}")
-    private String visionAppKey;
-    @NotNull
-    private final AnimalApiClient animalApiClient;
-    @NotNull
-    private final PostRepository postRepository;
-    @NotNull
-    private final KindRepository kindRepository;
-    @NotNull
-    private final ShelterRepository shelterRepository;
-    @NotNull
-    private final VisionApiClient visionApiClient;
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
     @NotNull
     private final VisionService visionService;
+    @NotNull
+    private final PostService postService;
 
-    public PostJob(AnimalApiClient animalApiClient,
-                   PostRepository postRepository,
-                   KindRepository kindRepository,
-                   ShelterRepository shelterRepository, VisionApiClient visionApiClient, VisionService visionService) {
-        this.animalApiClient = animalApiClient;
-        this.postRepository = postRepository;
-        this.kindRepository = kindRepository;
-        this.shelterRepository = shelterRepository;
-        this.visionApiClient = visionApiClient;
+    public PostJob(VisionService visionService, PostService postService) {
         this.visionService = visionService;
+        this.postService = postService;
     }
 
     @Scheduled(fixedRate = 10000000000L)
     public void image() throws Exception {
-        Gson gson = new Gson();
-        log.debug("[GOOGLE_VISION_REQUEST] vision api request json : {}", "http://www.animal.go.kr/files/shelter/2017/10/201710191410720.jpg");
-        VisionApiResponse result = visionApiClient.image(visionAppKey, createVisionApiRequest("http://www.animal.go.kr/files/shelter/2017/10/201710191410720.jpg"));
-        log.debug("[GOOGLE_VISION_RESPONSE] vision api response result : {}", result.toString());
-        visionService.create(result);
-        log.debug("[GOOGLE_VISION_COMPLETE] <================================================");
+        StopWatch stopWatch = new StopWatch();
+        log.debug("[GOOGLE_VISION_START]");
+        String nowDate = LocalDateTime.now()
+                                      .format(formatter);
+        stopWatch.start();
+        List<PostDTO> posts = postService.readPosts(nowDate, nowDate, EMPTY, EMPTY, EMPTY, "1", "10");
+        for (PostDTO post : posts) {
+            visionService.syncVisionData(post);
+        }
+        stopWatch.stop();
+        log.debug("[GOOGLE_VISION_COMPLETE] executionTime : {} millis", stopWatch.getLastTaskTimeMillis());
     }
 
     @Scheduled(cron = "0 0 2 1 1/1 ?") // 매달 1일 02시에 실행
@@ -107,7 +64,6 @@ public class PostJob {
 
     public void batch(BatchType type, Integer minus) {
         StopWatch stopWatch = new StopWatch();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
         LocalDateTime startDate = LocalDateTime.now();
         LocalDateTime endDate = LocalDateTime.now();
         if (BatchType.YEAR == type) {
@@ -128,201 +84,8 @@ public class PostJob {
         }
         log.info("[BATCH_START] type: {}, startDate : {}, endDate : {}", type, startDate.format(formatter), endDate.format(formatter));
         stopWatch.start();
-        posts(startDate.format(formatter), endDate.format(formatter));
+        postService.syncPosts(startDate.format(formatter), endDate.format(formatter));
         stopWatch.stop();
         log.info("[BATCH_END} executionTime : {} millis", stopWatch.getLastTaskTimeMillis());
-    }
-
-    public void posts(String beginDate, String endDate) {
-        String beginDateParam = beginDate;
-        String endDateParam = endDate;
-        if (isEmpty(beginDate)) {
-            beginDateParam = getDefaultDate(DATE_FORMAT);
-        }
-        if (isEmpty(endDate)) {
-            endDateParam = getDefaultDate(DATE_FORMAT);
-        }
-        AnimalApiResponse response = animalApiClient.animal(appKey, beginDateParam, endDateParam, EMPTY, EMPTY,
-                                                            EMPTY, EMPTY, EMPTY, EMPTY, START_INDEX, MAX_SIZE);
-        if (response != null) {
-            List<Post> posts = postRepository.findByHappenDateGreaterThanEqualAndHappenDateLessThanEqual(convertStringToDate(beginDate),
-                                                                                                         convertStringToDate(endDate));
-            List<AnimalApiResponse.Body.Items.AnimalItemDTO> animalItems = response.getBody()
-                                                                                   .getItems()
-                                                                                   .getItem();
-            log.info("AnimalItemDTO, beginDate : {}, endDate : {}, size : {}", beginDate, endDate, animalItems.size());
-            postRepository.save(animalItems.stream()
-                                           .map(this::transform)
-                                           .map(x -> {
-                                               posts.forEach(y -> {
-                                                   if (y.getDesertionId()
-                                                        .equals(x.getDesertionId())) {
-                                                       x.setId(y.getId());
-                                                       x.setCreatedDate(y.getCreatedDate());
-                                                   }
-                                               });
-                                               return x;
-                                           })
-                                           .collect(Collectors.toList()));
-        } else {
-            log.info("PostJob, post not found.. beginDate : {}, endDate : {}", beginDate, endDate);
-        }
-    }
-
-    private String getDefaultDate(String format) {
-        LocalDateTime now = LocalDateTime.now();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
-        return now.format(formatter);
-    }
-
-    private Post transform(AnimalApiResponse.Body.Items.AnimalItemDTO animalItemDTO) {
-        String kindName = convertKindName(animalItemDTO.getKindCd());
-        Kind mockKind = new Kind();
-        mockKind.setUpKindCode(-1L);
-        mockKind.setKindCode(-1L);
-        Kind kind = Optional.ofNullable(kindRepository.findByKindName(kindName))
-                            .orElse(mockKind);
-        String[] orgNames = animalItemDTO.getOrgNm()
-                                         .split(SPACE);
-        Shelter mockShelter = new Shelter();
-        mockShelter.setCityCode(-1L);
-        mockShelter.setCityName(UNKNOWN);
-        mockShelter.setTownCode(-1L);
-        mockShelter.setTownName(UNKNOWN);
-        mockShelter.setShelterCode(-1L);
-        mockShelter.setShelterName(UNKNOWN);
-        Shelter shelter = new Shelter();
-        switch (orgNames.length) {
-            case 1:
-                shelter = shelterRepository.findByCityName(orgNames[0])
-                                           .stream()
-                                           .findFirst()
-                                           .orElse(mockShelter);
-                break;
-            case 2:
-                shelter = shelterRepository.findByTownName(orgNames[1])
-                                           .stream()
-                                           .findFirst()
-                                           .orElse(mockShelter);
-                break;
-        }
-        if ("-1".equals(shelter.getTownCode())) {
-            shelter = shelterRepository.findByShelterName(animalItemDTO.getCareNm())
-                                       .stream()
-                                       .findFirst()
-                                       .orElse(mockShelter);
-        }
-        Post post = new Post();
-        post.setDesertionId(Long.valueOf(animalItemDTO.getDesertionNo()));
-        post.setImageUrl(animalItemDTO.getPopfile());
-        post.setType(PostType.SYSTEM.getCode());
-        post.setState(animalItemDTO.getProcessState());
-        post.setGender(animalItemDTO.getSexCd());
-        post.setNeuter(isEmpty(animalItemDTO.getNeuterYn()) ? NeuterType.U.name() : animalItemDTO.getNeuterYn());
-        post.setUserId(PostType.SYSTEM.getCode());
-        post.setUserName(animalItemDTO.getCareNm());
-        post.setUserAddress(animalItemDTO.getCareAddr());
-        post.setUserContact(animalItemDTO.getCareTel());
-        post.setHappenDate(convertStringToDate(animalItemDTO.getHappenDt()));
-        post.setHappenPlace(isNotEmpty(animalItemDTO.getOrgNm()) ? animalItemDTO.getOrgNm() : UNKNOWN);
-        post.setUprCode(String.valueOf(shelter.getCityCode()));
-        post.setOrgCode(String.valueOf(shelter.getTownCode()));
-        post.setKindUpCode(String.valueOf(kind.getUpKindCode()));
-        post.setKindCode(String.valueOf(kind.getKindCode()));
-        try {
-            post.setAge(Integer.valueOf(convertAge(animalItemDTO.getAge())));
-        } catch (NumberFormatException nfe) {
-            post.setAge(-1);
-        }
-        post.setWeight(Float.valueOf(convertWeight(animalItemDTO.getWeight())));
-        post.setIntroduction(animalItemDTO.getNoticeComment());
-        post.setFeature(animalItemDTO.getSpecialMark());
-        post.setIsDisplay(TRUE);
-        return post;
-    }
-
-    private String convertWeight(String weight) {
-        if (isEmpty(weight)) {
-            return "-1";
-        }
-        if (weight.contains("(Kg)")) {
-            weight = weight.replace("(Kg)", "");
-            try {
-                Float.valueOf(weight);
-            } catch (NumberFormatException nfe) {
-                weight = "-1";
-            }
-        }
-        return weight;
-    }
-
-    private String convertAge(String age) {
-        String result = age.replace(" ", "");
-        if (isEmpty(result) || isAllBlank(result)) {
-            return "-1";
-        }
-        if (result.contains("(년생)")) {
-            return result.replace("(년생)", "");
-        }
-        return result;
-    }
-
-    private String convertKindName(String kindName) {
-        if (kindName.contains("[개] ")) {
-            return kindName.replace("[개] ", "");
-        }
-        if (kindName.contains("[기타축종] ")) {
-            return kindName.replace("[기타축종] ", "");
-        }
-        if (kindName.contains("[고양이]")) {
-            return kindName.replace("[고양이]", "고양이");
-        }
-        return kindName;
-    }
-
-    private String convertDateToString(Date date) {
-        SimpleDateFormat transFormat = new SimpleDateFormat(DATE_FORMAT);
-        return transFormat.format(date);
-    }
-
-    private Date convertStringToDate(String from) {
-        SimpleDateFormat transFormat = new SimpleDateFormat(DATE_FORMAT);
-        try {
-            return transFormat.parse(from);
-        } catch (ParseException e) {
-            e.printStackTrace();
-        }
-        return new Date();
-    }
-
-    private VisionApiRequest createVisionApiRequest(String imageUrl) {
-        List<Request> requests = new ArrayList<>();
-        List<Feature> features = new ArrayList<>();
-        features.add(Feature.builder()
-                            .type("LABEL_DETECTION")
-                            .build());
-/*        features.add(Feature.builder()
-                            .type("FACE_DETECTION")
-                            .build());*/
-        features.add(Feature.builder()
-                            .type("IMAGE_PROPERTIES")
-                            .build());
-        features.add(Feature.builder()
-                            .type("SAFE_SEARCH_DETECTION")
-                            .build());
-/*        features.add(Feature.builder()
-                            .type("CROP_HINTS")
-                            .build());*/
-        requests.add(Request.builder()
-                            .image(Request.Image.builder()
-                                                .source(Request.Image.Source.builder()
-                                                                            .imageUri(imageUrl)
-                                                                            .build())
-                                                .build())
-                            .features(features)
-                            .build());
-        return VisionApiRequest.builder()
-                               .requests(requests)
-                               .build();
     }
 }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -30,18 +30,14 @@ public class PostJob {
         this.postService = postService;
     }
 
-    @Scheduled(fixedRate = 10000000000L)
     public void image() throws Exception {
         StopWatch stopWatch = new StopWatch();
         log.debug("[GOOGLE_VISION_START]");
-        String nowDate = LocalDateTime.now()
+        String baseDate = LocalDateTime.now().minusDays(1)
                                       .format(formatter);
         stopWatch.start();
-        List<PostDTO> posts = postService.readPosts(nowDate, nowDate, EMPTY, EMPTY, EMPTY, "1", "1");
-        for (PostDTO post : posts) {
-            visionService.syncVisionData(post);
-        }
-//        visionService.syncVisionData(posts);
+        List<PostDTO> posts = postService.readPosts(baseDate, baseDate, EMPTY, EMPTY, EMPTY, "1", "1");
+        visionService.syncVisionData(posts);
         stopWatch.stop();
         log.debug("[GOOGLE_VISION_COMPLETE] executionTime : {} millis", stopWatch.getLastTaskTimeMillis());
     }

--- a/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
+++ b/papao-api/src/main/java/com/papaolabs/api/infrastructure/persistence/scheduler/PostJob.java
@@ -78,11 +78,11 @@ public class PostJob {
         this.visionService = visionService;
     }
 
-    @Scheduled(fixedRate = 100000000L)
+    @Scheduled(fixedRate = 10000000000L)
     public void image() throws Exception {
         Gson gson = new Gson();
-        log.debug("[GOOGLE_VISION_REQUEST] vision api request json : {}", gson.toJson(createVisionApiRequest("http://www.animal.go.kr/files/shelter/2017/10/201710191010667.jpg")));
-        VisionApiResponse result = visionApiClient.image(visionAppKey, createVisionApiRequest("http://www.animal.go.kr/files/shelter/2017/10/201710191010667.jpg"));
+        log.debug("[GOOGLE_VISION_REQUEST] vision api request json : {}", "http://www.animal.go.kr/files/shelter/2017/10/201710191410720.jpg");
+        VisionApiResponse result = visionApiClient.image(visionAppKey, createVisionApiRequest("http://www.animal.go.kr/files/shelter/2017/10/201710191410720.jpg"));
         log.debug("[GOOGLE_VISION_RESPONSE] vision api response result : {}", result.toString());
         visionService.create(result);
         log.debug("[GOOGLE_VISION_COMPLETE] <================================================");

--- a/papao-api/src/main/resources/application.yml
+++ b/papao-api/src/main/resources/application.yml
@@ -32,6 +32,12 @@ seoul:
     animal:
       appKey: ENC(xOX84cNWVjfcMoTpV2n8ntEmkOqwAGzHJlS3s+QVz7ZOcLmBLJNScqUEH9KzYnW9K/4tdVLRCIM8u11Ij59cQoXgCvkwoMfeDj/XkRA+Ley+AXMbsoVVuTPds0z7SjLd7t4RSFdx9dE=)
       url: http://openapi.animal.go.kr/openapi/service/rest/abandonmentPublicSrvc
+
+google:
+  application:
+    imageUrl: https://vision.googleapis.com/v1
+    key: ENC(J10GTNRuMxFnd6Y04emdEj07yr7N+5Rl9td8K9jKbCc4T24UBh0yxmE08BXQRV8h)
+
 ---
 spring.profiles: local
 


### PR DESCRIPTION
### Updates
* google visoin api, feign 을 통한 연동
* 관련 batch 로직 작성
* batch 코드 분리
* vision 관련 테이블 추가

### Description
* apiKey 를 통한 vision api 연동, 클라이언트를 사용하지 않고 feign 을 통하여 자체 구축함
* 기존 결과값에 post id, imageUrl 을 매핑하는 상태임, imageUrl 의 경우 차후 제거
* 시스템 로직 상 필요없어 보이는 결과들은 필터링 진행하도록 함, 현재는 Label 의 name 정도가 너무 큰 범주로 들어올 때 필터 처리함 (ex - Dog, Cat 등등... )
* 색상 / 오브젝트 속성 / 이미지 자체의 위험성? 을 저장하는 상태임

### How to Test
```
BRANCH=feature/PAPAOAPI-74; git fetch origin $BRANCH && git checkout $BRANCH &&  git pull && ./gradlew clean test
```